### PR TITLE
Fix: Update "got" dependency to 11.8.5

### DIFF
--- a/programming/misc/web-driver-io-test/package-lock.json
+++ b/programming/misc/web-driver-io-test/package-lock.json
@@ -148,7 +148,7 @@
       "integrity": "sha512-Zo98/Il0pDQRnV2n22L2qxzK9EyO2AQNArxnLsCyzL6G0st/fq9lUigZccK+mZLDO567bvCAhttKz6ldQe3eHg==",
       "dependencies": {
         "@types/node": "^17.0.4",
-        "got": "^11.8.1"
+        "got": "^11.8.5"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -1627,7 +1627,7 @@
         "@wdio/protocols": "7.19.0",
         "@wdio/types": "7.19.0",
         "@wdio/utils": "7.19.0",
-        "got": "^11.0.2",
+        "got": "^11.8.5",
         "ky": "^0.30.0",
         "lodash.merge": "^4.6.1"
       },
@@ -1865,7 +1865,7 @@
       "integrity": "sha512-Zo98/Il0pDQRnV2n22L2qxzK9EyO2AQNArxnLsCyzL6G0st/fq9lUigZccK+mZLDO567bvCAhttKz6ldQe3eHg==",
       "requires": {
         "@types/node": "^17.0.4",
-        "got": "^11.8.1"
+        "got": "^11.8.5"
       }
     },
     "@wdio/utils": {
@@ -2347,9 +2347,9 @@
       }
     },
     "got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -2972,7 +2972,7 @@
         "@wdio/protocols": "7.19.0",
         "@wdio/types": "7.19.0",
         "@wdio/utils": "7.19.0",
-        "got": "^11.0.2",
+        "got": "^11.8.5",
         "ky": "^0.30.0",
         "lodash.merge": "^4.6.1"
       }


### PR DESCRIPTION
I've updated the transitive dependency "got" from 11.8.3 to 11.8.5 in `programming/misc/web-driver-io-test/package-lock.json`.

This update includes a security fix for CVE-2022-33987, which prevents redirects to UNIX sockets.

I've updated the `package-lock.json` and ran `npm install` to ensure consistency. No functional tests were available in the package to verify this change, but the update is minor and primarily for a security patch.

Note: `npm audit` revealed 6 unrelated high-severity vulnerabilities in other dependencies (`tar-fs`, `ua-parser-js`, `ws`). These are pre-existing and not introduced by this change.